### PR TITLE
pairhmm: add rust implementations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,11 @@ jobs:
       run: |
         rustup install ${{matrix.rust}}
         rustup default ${{matrix.rust}}
-    - name: Test debug
-      run: cargo test --verbose
-    - name: Test release
-      run: cargo test --verbose --release
+    - run: cargo test --verbose
+    - run: cargo test --verbose --release
+    - run: cargo test --verbose --features c
+    - run: cargo test --verbose --features nightly
+      if: matrix.rust == 'nightly'
 
   bench:
     runs-on: ubuntu-latest
@@ -29,11 +30,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install rust
       run: |
-        rustup install stable
-        rustup default stable
+        rustup install nightly
+        rustup default nightly
         cargo install cargo-criterion
-    - name: Bench
-      run: cargo criterion --no-run
+    - run: cargo criterion --no-run
+    - run: cargo criterion --no-run --features c
+    - run: cargo criterion --no-run --features nightly
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,35 @@ repository = "https://github.com/philipc/gkl-rs"
 description = "Genomics Kernel Library"
 
 [dependencies]
+cfg-if = "1.0"
 lazy_static = "1.3.0"
+num-traits = "0.2.14"
 
 [build-dependencies]
 cc = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"
+
+[features]
+# Use nightly rustc SIMD features.
+# This enables support for AVX-512.
+nightly = []
+
+# Enable C++ implementations for PairHMM algorithms.
+# This is usually only useful for comparison.
+c = ["c-avx", "c-avx512"]
+
+# Enable C++ AVX implementations for PairHMM algorithms.
+# This is usually only useful for comparison.
+c-avx = ["c-core"]
+
+# Enable C++ AVX-512 implementations for PairHMM algorithms.
+# This enables support for AVX-512 without requiring nightly rustc features.
+c-avx512 = ["c-core"]
+
+# Internal use.
+c-core = []
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/philipc/gkl-rs"
 description = "Genomics Kernel Library"
 
 [dependencies]
+lazy_static = "1.3.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
 
 use std::cmp;
 use std::fs::File;
@@ -77,4 +77,19 @@ fn bench(c: &mut Criterion) {
         let f = gkl::pairhmm::forward;
         c.bench_function("forward_any", |b| b.iter(|| bench!(f)));
     }
+
+    let mut group = c.benchmark_group("slow");
+    group.sample_size(10).sampling_mode(SamplingMode::Flat);
+
+    {
+        let f = gkl::pairhmm::forward_f32x1();
+        group.bench_function("forward_f32x1", |b| b.iter(|| bench!(f)));
+    }
+
+    {
+        let f = gkl::pairhmm::forward_f64x1();
+        group.bench_function("forward_f64x1", |b| b.iter(|| bench!(f)));
+    }
+
+    group.finish();
 }

--- a/benches/pairhmm.rs
+++ b/benches/pairhmm.rs
@@ -57,33 +57,24 @@ fn bench(c: &mut Criterion) {
         };
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f32_avx() {
+    if let Some(f) = gkl::pairhmm::forward_f32x8() {
         c.bench_function("forward_f32x8", |b| b.iter(|| bench!(f)));
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f32_avx512() {
+    if let Some(f) = gkl::pairhmm::forward_f32x16() {
         c.bench_function("forward_f32x16", |b| b.iter(|| bench!(f)));
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f64_avx() {
+    if let Some(f) = gkl::pairhmm::forward_f64x4() {
         c.bench_function("forward_f64x4", |b| b.iter(|| bench!(f)));
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f64_avx512() {
+    if let Some(f) = gkl::pairhmm::forward_f64x8() {
         c.bench_function("forward_f64x8", |b| b.iter(|| bench!(f)));
     }
 
-    if let Some(f) = gkl::pairhmm::forward() {
-        c.bench_function("forward_any", |b| {
-            b.iter(|| {
-                for (rs, hap) in &tests {
-                    for (rs, q, i, d, c) in rs.iter() {
-                        for hap in hap.iter() {
-                            f(hap.as_bytes(), rs, q, i, d, c);
-                        }
-                    }
-                }
-            })
-        });
+    {
+        let f = gkl::pairhmm::forward;
+        c.bench_function("forward_any", |b| b.iter(|| bench!(f)));
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ fn main() {
         .file("gkl/smithwaterman/smithwaterman_common.cc")
         .warnings(false)
         .compile("gkl-common");
+    #[cfg(feature = "c-avx")]
     cc::Build::new()
         .cpp(true)
         .file("gkl/pairhmm/avx_impl.cc")
@@ -19,6 +20,7 @@ fn main() {
         .flag("-mavx2")
         .warnings(false)
         .compile("gkl-sw-avx2");
+    #[cfg(feature = "c-avx512")]
     cc::Build::new()
         .cpp(true)
         .file("gkl/pairhmm/avx512_impl.cc")

--- a/gkl/pairhmm/avx512_impl.cc
+++ b/gkl/pairhmm/avx512_impl.cc
@@ -38,18 +38,3 @@ double compute_avx512d(testcase *tc)
   double result = compute_full_prob_avx512d<double>(tc);
   return log10(result) - g_ctxd.LOG10_INITIAL_CONSTANT;
 }
-
-double compute_avx512(testcase *tc)
-{
-  double result_final = 0;
-  float result_float = compute_full_prob_avx512s<float>(tc);
-
-  if (result_float < MIN_ACCEPTED) {
-    double result_double = compute_full_prob_avx512d<double>(tc);
-    result_final = log10(result_double) - g_ctxd.LOG10_INITIAL_CONSTANT;
-  }
-  else {
-    result_final = (double)(log10f(result_float) - g_ctxf.LOG10_INITIAL_CONSTANT);
-  }
-  return result_final;
-}

--- a/gkl/pairhmm/avx512_impl.h
+++ b/gkl/pairhmm/avx512_impl.h
@@ -28,7 +28,6 @@
 
 extern "C" float compute_avx512s(testcase*);
 extern "C" double compute_avx512d(testcase*);
-extern "C" double compute_avx512(testcase*);
 
 #endif //AVX512_IMPL_H
 

--- a/gkl/pairhmm/avx_impl.cc
+++ b/gkl/pairhmm/avx_impl.cc
@@ -38,18 +38,3 @@ double compute_avxd(testcase *tc)
   double result = compute_full_prob_avxd<double>(tc);
   return log10(result) - g_ctxd.LOG10_INITIAL_CONSTANT;
 }
-
-double compute_avx(testcase *tc)
-{
-  double result_final = 0;
-  float result_float = compute_full_prob_avxs<float>(tc);
-
-  if (result_float < MIN_ACCEPTED) {
-    double result_double = compute_full_prob_avxd<double>(tc);
-    result_final = log10(result_double) - g_ctxd.LOG10_INITIAL_CONSTANT;
-  }
-  else {
-    result_final = (double)(log10f(result_float) - g_ctxf.LOG10_INITIAL_CONSTANT);
-  }
-  return result_final;
-}

--- a/gkl/pairhmm/avx_impl.h
+++ b/gkl/pairhmm/avx_impl.h
@@ -28,7 +28,6 @@
 
 extern "C" float compute_avxs(testcase*);
 extern "C" double compute_avxd(testcase*);
-extern "C" double compute_avx(testcase*);
 
 #endif //AVX_IMPL_H
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 //! - AVX and AVX-512 versions of the PairHMM forward algorithm
 //! - AVX2 and AVX-512 versions of the Smith-Waterman sequence alignment algorithm
 #![deny(missing_docs)]
+#![cfg_attr(feature = "nightly", feature(avx512_target_feature, stdsimd))]
+
+mod vector;
 
 pub mod pairhmm;
 pub mod smithwaterman;

--- a/src/pairhmm.rs
+++ b/src/pairhmm.rs
@@ -1,63 +1,14 @@
-//! AVX and AVX-512 versions of the PairHMM forward algorithm.
-
-use std::convert::TryInto;
-use std::os::raw::{c_char, c_int};
+//! PairHMM forward algorithm.
+use crate::vector::Vector;
+use num_traits::{Float, One, Zero};
+use std::{cmp, mem};
 
 lazy_static::lazy_static! {
     static ref FORWARD32: Option<ForwardF32> = forward_f32();
-    static ref FORWARD64: Option<Forward> = forward_f64();
+    static ref FORWARD64: Forward = forward_f64();
     static ref LOG10_INITIAL_CONSTANT_32: f32 = (120.0f32).exp2().log10();
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-struct Testcase {
-    rslen: c_int,
-    haplen: c_int,
-    q: *const c_char,
-    i: *const c_char,
-    d: *const c_char,
-    c: *const c_char,
-    hap: *const c_char,
-    rs: *const c_char,
-}
-
-extern "C" {
-    fn compute_avxs(arg1: *mut Testcase) -> f32;
-    fn compute_avxd(arg1: *mut Testcase) -> f64;
-    fn compute_avx512s(arg1: *mut Testcase) -> f32;
-    fn compute_avx512d(arg1: *mut Testcase) -> f64;
-    #[link_name = "\u{1}_ZN11ConvertChar15conversionTableE"]
-    static mut ConvertChar_conversionTable: [u8; 255usize];
-}
-
-fn convert_char_init() {
-    unsafe {
-        ConvertChar_conversionTable[b'A' as usize] = 0;
-        ConvertChar_conversionTable[b'C' as usize] = 1;
-        ConvertChar_conversionTable[b'T' as usize] = 2;
-        ConvertChar_conversionTable[b'G' as usize] = 3;
-        ConvertChar_conversionTable[b'N' as usize] = 4;
-    }
-}
-
-fn testcase(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> Testcase {
-    let haplen = hap.len();
-    let rslen = rs.len();
-    assert_eq!(rslen, q.len());
-    assert_eq!(rslen, i.len());
-    assert_eq!(rslen, d.len());
-    assert_eq!(rslen, c.len());
-    Testcase {
-        rslen: rslen.try_into().unwrap(),
-        haplen: haplen.try_into().unwrap(),
-        q: q.as_ptr() as *const c_char,
-        i: i.as_ptr() as *const c_char,
-        d: d.as_ptr() as *const c_char,
-        c: c.as_ptr() as *const c_char,
-        hap: hap.as_ptr() as *const c_char,
-        rs: rs.as_ptr() as *const c_char,
-    }
+    static ref CONTEXT32: Context<f32> = Context::new();
+    static ref CONTEXT64: Context<f64> = Context::new();
 }
 
 /// The type of a PairHMM forward function that returns an `f32`.
@@ -70,72 +21,94 @@ pub type ForwardF32 = fn(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c:
 /// This is returned by the CPU feature detection functions.
 pub type Forward = fn(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64;
 
+/// Return the scalar `f32` implementation of the PairHMM forward function.
+///
+/// The compiler may autovectorize this function.
+///
+/// This may be slower than the scalar `f64` implementation due to autovectorization differences.
+pub fn forward_f32x1() -> ForwardF32 {
+    fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
+        let ctx = &CONTEXT32;
+        unsafe { compute::<f32>(ctx, hap, rs, q, i, d, c) }
+    }
+    f
+}
+
+/// Return the scalar `f64` implementation of the PairHMM forward function.
+///
+/// The compiler may autovectorize this function.
+pub fn forward_f64x1() -> Forward {
+    fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
+        let ctx = &CONTEXT64;
+        unsafe { compute::<f64>(ctx, hap, rs, q, i, d, c) }
+    }
+    f
+}
+
 /// Return the `f32x8` implementation of the PairHMM forward function if supported by the CPU features.
 pub fn forward_f32x8() -> Option<ForwardF32> {
-    if !is_x86_feature_detected!("avx") {
-        return None;
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_arch = "x86_64", feature = "c-avx"))] {
+            c::forward_f32x8()
+        } else if #[cfg(target_arch = "x86_64")] {
+            x86_64_avx::forward_f32x8()
+        } else {
+            None
+        }
     }
-    convert_char_init();
-    fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
-        let mut tc = testcase(hap, rs, q, i, d, c);
-        unsafe { compute_avxs(&mut tc) }
-    }
-    Some(f)
 }
 
 /// Return the `f64x4` implementation of the PairHMM forward function if supported by the CPU features.
 pub fn forward_f64x4() -> Option<Forward> {
-    if !is_x86_feature_detected!("avx") {
-        return None;
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_arch = "x86_64", feature = "c-avx"))] {
+            c::forward_f64x4()
+        } else if #[cfg(target_arch = "x86_64")] {
+            x86_64_avx::forward_f64x4()
+        } else {
+            None
+        }
     }
-    convert_char_init();
-    fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
-        let mut tc = testcase(hap, rs, q, i, d, c);
-        unsafe { compute_avxd(&mut tc) }
-    }
-    Some(f)
 }
 
 /// Return the `f32x16` implementation of the PairHMM forward function if supported by the CPU features.
 pub fn forward_f32x16() -> Option<ForwardF32> {
-    if !is_x86_feature_detected!("avx512f")
-        || !is_x86_feature_detected!("avx512dq")
-        || !is_x86_feature_detected!("avx512vl")
-    {
-        return None;
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_arch = "x86_64", feature = "c-avx512"))] {
+            c::forward_f32x16()
+        } else if #[cfg(all(target_arch = "x86_64", feature = "nightly"))] {
+            x86_64_avx512::forward_f32x16()
+        } else {
+            None
+        }
     }
-    convert_char_init();
-    fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
-        let mut tc = testcase(hap, rs, q, i, d, c);
-        unsafe { compute_avx512s(&mut tc) }
-    }
-    Some(f)
 }
 
 /// Return the `f64x8` implementation of the PairHMM forward function if supported by the CPU features.
 pub fn forward_f64x8() -> Option<Forward> {
-    if !is_x86_feature_detected!("avx512f")
-        || !is_x86_feature_detected!("avx512dq")
-        || !is_x86_feature_detected!("avx512vl")
-    {
-        return None;
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_arch = "x86_64", feature = "c-avx512"))] {
+            c::forward_f64x8()
+        } else if #[cfg(all(target_arch = "x86_64", feature = "nightly"))] {
+            x86_64_avx512::forward_f64x8()
+        } else {
+            None
+        }
     }
-    convert_char_init();
-    fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
-        let mut tc = testcase(hap, rs, q, i, d, c);
-        unsafe { compute_avx512d(&mut tc) }
-    }
-    Some(f)
 }
 
 /// Return the fastest `f32` PairHMM forward function that is supported by the CPU features.
+///
+/// Does not return `forward_f32x1` since `forward_f64x1` may be faster.
 pub fn forward_f32() -> Option<ForwardF32> {
     forward_f32x16().or_else(forward_f32x8)
 }
 
 /// Return the fastest `f64` PairHMM forward function that is supported by the CPU features.
-pub fn forward_f64() -> Option<Forward> {
-    forward_f64x8().or_else(forward_f64x4)
+pub fn forward_f64() -> Forward {
+    forward_f64x8()
+        .or_else(forward_f64x4)
+        .unwrap_or_else(forward_f64x1)
 }
 
 /// Use the fastest PairHMM forward function this is supported by the CPU features.
@@ -149,6 +122,591 @@ pub fn forward(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) ->
             return result as f64;
         }
     }
-    // TODO: provide fallback implemenation
-    FORWARD64.unwrap()(hap, rs, q, i, d, c)
+    FORWARD64(hap, rs, q, i, d, c)
+}
+
+trait ContextFloat: Float + From<u8> {
+    const INITIAL_CONSTANT_EXP: Self;
+    const TEN: Self;
+}
+
+impl ContextFloat for f32 {
+    const INITIAL_CONSTANT_EXP: Self = 120.0;
+    const TEN: Self = 10.0;
+}
+
+impl ContextFloat for f64 {
+    const INITIAL_CONSTANT_EXP: Self = 1020.0;
+    const TEN: Self = 10.0;
+}
+
+/// Context containing calculations that can be reused for different data.
+struct Context<T: ContextFloat> {
+    initial_constant: T,
+    log10_initial_constant: T,
+    convert: [u8; 256],
+    ph2pr: [T; 128],
+    match_to_match_prob: Vec<T>,
+}
+
+impl<T: ContextFloat> Context<T> {
+    const MAX_QUAL: u8 = 127;
+
+    fn new() -> Self {
+        let initial_constant = T::INITIAL_CONSTANT_EXP.exp2();
+        let log10_initial_constant = initial_constant.log10();
+
+        let mut convert = [0; 256];
+        convert[b'A' as usize] = 0;
+        convert[b'C' as usize] = 1;
+        convert[b'T' as usize] = 2;
+        convert[b'G' as usize] = 3;
+        convert[b'N' as usize] = 4;
+
+        let mut ph2pr = [T::zero(); 128];
+        for x in 0..128u8 {
+            ph2pr[x as usize] = T::TEN.powf(-(<T as From<u8>>::from(x) / T::TEN));
+        }
+
+        let inv_ln10 = T::one() / T::TEN.ln();
+        let mut match_to_match_prob =
+            Vec::with_capacity(((Self::MAX_QUAL as usize + 1) * (Self::MAX_QUAL as usize + 2)) / 2);
+        for i in 0..=Self::MAX_QUAL {
+            for j in 0..=i {
+                let a = <T as num_traits::NumCast>::from(-0.1f32).unwrap() * From::from(i);
+                let b = <T as num_traits::NumCast>::from(-0.1f32).unwrap() * From::from(j);
+                let sum = T::TEN.powf(a) + T::TEN.powf(b);
+                let match_to_match_log10 = (-T::min(T::one(), sum)).ln_1p() * inv_ln10;
+                match_to_match_prob.push(T::TEN.powf(match_to_match_log10));
+            }
+        }
+
+        Context {
+            convert,
+            initial_constant,
+            log10_initial_constant,
+            ph2pr,
+            match_to_match_prob,
+        }
+    }
+
+    fn match_to_match_prob(&self, mut a: u8, mut b: u8) -> T {
+        if a > b {
+            mem::swap(&mut a, &mut b);
+        }
+        debug_assert!(b <= Self::MAX_QUAL);
+        self.match_to_match_prob[((b as usize * (b as usize + 1)) / 2) + a as usize]
+    }
+}
+
+struct BitMaskVec<V: Vector> {
+    rows: V::IndexArray,
+    shift: V::MaskArray,
+    col_masks: Vec<[V::Mask; 5]>,
+}
+
+impl<V: Vector> BitMaskVec<V> {
+    fn new(hap: &[u8], convert: &[u8; 256]) -> Self {
+        // Number of antidiagonals in a stripe.
+        let max_d = hap.len() + V::LANES - 1;
+        let mut col_masks = vec![
+            [
+                V::Mask::default(),
+                V::Mask::default(),
+                V::Mask::default(),
+                V::Mask::default(),
+                !V::Mask::default()
+            ];
+            (max_d + V::MASK_BITS - 1) / V::MASK_BITS
+        ];
+        for (col, hap) in hap.iter().copied().enumerate() {
+            let masks = &mut col_masks[col / V::MASK_BITS];
+            let bit = V::Mask::from(1) << (V::MASK_BITS - 1 - col % V::MASK_BITS);
+            let hap = convert[hap as usize];
+            if hap == 4 {
+                for j in 0..5 {
+                    masks[j] |= bit;
+                }
+            } else {
+                masks[hap as usize] |= bit;
+            }
+        }
+        BitMaskVec {
+            rows: V::IndexArray::default(),
+            shift: V::MaskArray::default(),
+            col_masks,
+        }
+    }
+
+    fn init_row(&mut self, rs: &[u8], convert: &[u8; 256]) {
+        for (i, rs) in rs.iter().take(V::LANES).copied().enumerate() {
+            self.rows[i] = convert[rs as usize];
+        }
+        self.shift = V::MaskArray::default();
+    }
+
+    // Build a mask for use with Vector::blend to select between
+    // distm and 1-distm.
+    //
+    // Only the MSB of each element is used for the blend, but then we
+    // shift left for the next loop.
+    //
+    // Each element corresponds to a row, and each bit corresponds to a column.
+    // A bit is set if the row and column match.
+    fn match_col(&mut self, index: usize) -> V::MaskVec {
+        let mut masks = V::MaskArray::default();
+        masks[0] = self.col_masks[index][self.rows[0] as usize];
+        for row in 1..V::LANES {
+            let mask = self.col_masks[index][self.rows[row] as usize];
+            // The shifts are due to using antidiagonals.
+            masks[row] = (mask >> row) | self.shift[row];
+            self.shift[row] = mask << (V::MASK_BITS - row);
+        }
+        V::mask_from_array(masks)
+    }
+}
+
+/// Perform the PairHMM forward calculation.
+///
+/// Operations are on horizontal stripes. The number of rows in a stripe is equal
+/// to the number of vector lanes. Each stripe depends on the last row of the
+/// previous stripe.
+///
+/// Operations within stripes are on antidiagonals. Each antidiagonal depends on
+/// the previous two antidiagonals.
+///
+/// # Panics
+/// Panics when `rs.len() == 0`.
+/// Panics when the length of `q`, `i`, `d` or `c` is less than the length of `rs`.
+#[inline]
+unsafe fn compute<V: Vector>(
+    ctx: &Context<V::Float>,
+    hap: &[u8],
+    rs: &[u8],
+    q: &[u8],
+    i: &[u8],
+    d: &[u8],
+    c: &[u8],
+) -> V::Float
+where
+    V::Float: ContextFloat,
+{
+    let mut bitmask_vec = BitMaskVec::<V>::new(hap, &ctx.convert);
+
+    let mode = V::set_flush_zero_mode();
+
+    let shift_len = hap.len() + rs.len() + V::LANES;
+    let mut shift_m = vec![V::Float::zero(); shift_len];
+    let mut shift_x = vec![V::Float::zero(); shift_len];
+    let init_y = ctx.initial_constant / num_traits::NumCast::from(hap.len()).unwrap();
+    let mut shift_y = vec![init_y; shift_len];
+
+    let mut m_t_1 = V::zero();
+    let mut m_t_1_y = V::zero();
+    let mut m_t_2 = V::zero();
+    let mut x_t_1 = V::zero();
+    let mut x_t_2 = V::zero();
+    let mut y_t_1 = V::zero();
+    let mut y_t_2 = V::first_element(init_y);
+
+    assert!(rs.len() > 0);
+    let mut stripe_cnt = (rs.len() + V::LANES - 1) / V::LANES;
+    // The last stripe needs to be handled differently to generate the sum.
+    stripe_cnt -= 1;
+    let remaining_rows = rs.len() - stripe_cnt * V::LANES;
+
+    for stripe in 0..stripe_cnt {
+        let row_base = stripe * V::LANES;
+        let mut p_gapm = V::FloatArray::default();
+        let mut p_mm = V::FloatArray::default();
+        let mut p_mx = V::FloatArray::default();
+        let mut p_xx = V::FloatArray::default();
+        let mut p_my = V::FloatArray::default();
+        let mut p_yy = V::FloatArray::default();
+        let mut distm = V::FloatArray::default();
+        for r in 0..V::LANES {
+            let row = row_base + r;
+            let i = i[row] & 127;
+            let d = d[row] & 127;
+            let c = c[row] & 127;
+            p_gapm[r] = V::Float::one() - ctx.ph2pr[c as usize];
+            p_mm[r] = ctx.match_to_match_prob(i, d);
+            p_mx[r] = ctx.ph2pr[i as usize];
+            p_xx[r] = ctx.ph2pr[c as usize];
+            p_my[r] = ctx.ph2pr[d as usize];
+            p_yy[r] = ctx.ph2pr[c as usize];
+
+            let q = q[row] & 127;
+            distm[r] = ctx.ph2pr[q as usize];
+        }
+        let p_gapm = V::from_array(p_gapm);
+        let p_mm = V::from_array(p_mm);
+        let p_mx = V::from_array(p_mx);
+        let p_xx = V::from_array(p_xx);
+        let p_my = V::from_array(p_my);
+        let p_yy = V::from_array(p_yy);
+        let distm = V::from_array(distm);
+        let one_distm = V::sub(V::splat(V::Float::one()), distm);
+        let distm = V::div(distm, V::splat(V::Float::from(3)));
+
+        bitmask_vec.init_row(&rs[row_base..], &ctx.convert);
+        let mut begin_d = 0;
+        let max_d = hap.len() + V::LANES - 1;
+        while begin_d < max_d {
+            let mut bitmask = bitmask_vec.match_col(begin_d / V::MASK_BITS);
+            let num_d = cmp::min(max_d - begin_d, V::MASK_BITS);
+            for d in 0..num_d {
+                let shift_idx = begin_d + d;
+                debug_assert!(shift_idx + V::LANES < shift_len);
+
+                let m_t_base = V::add(
+                    V::add(V::mul(m_t_2, p_mm), V::mul(x_t_2, p_gapm)),
+                    V::mul(y_t_2, p_gapm),
+                );
+                m_t_2 = m_t_1;
+                x_t_2 = x_t_1;
+                y_t_2 = V::element_shift(
+                    y_t_1,
+                    shift_y.get_unchecked(shift_idx + V::LANES),
+                    shift_y.get_unchecked_mut(shift_idx),
+                );
+
+                let distm_sel = V::blend(distm, one_distm, bitmask);
+                bitmask = V::mask_shift(bitmask);
+                let m_t = V::mul(m_t_base, distm_sel);
+
+                let x_t = V::add(V::mul(m_t_1, p_mx), V::mul(x_t_1, p_xx));
+                m_t_1 = V::element_shift(
+                    m_t,
+                    shift_m.get_unchecked(shift_idx + V::LANES),
+                    shift_m.get_unchecked_mut(shift_idx),
+                );
+
+                let y_t = V::add(V::mul(m_t_1_y, p_my), V::mul(y_t_1, p_yy));
+                y_t_1 = y_t;
+
+                x_t_1 = V::element_shift(
+                    x_t,
+                    shift_x.get_unchecked(shift_idx + V::LANES),
+                    shift_x.get_unchecked_mut(shift_idx),
+                );
+                m_t_1_y = m_t;
+            }
+            begin_d += V::MASK_BITS;
+        }
+
+        m_t_1 = V::first_element(shift_m[V::LANES - 1]);
+        m_t_1_y = m_t_1;
+        m_t_2 = V::zero();
+        x_t_1 = V::first_element(shift_x[V::LANES - 1]);
+        x_t_2 = V::zero();
+        y_t_1 = V::zero();
+        y_t_2 = V::zero();
+    }
+
+    // The result is the sum of M and X in the last row of the last stripe.
+    // Since extracting the last row from the vector can be slow, we sum across
+    // all lanes in the stripe, and then extract the last row once at the end.
+    let mut sum_m = V::zero();
+    let mut sum_x = V::zero();
+    {
+        let row_base = stripe_cnt * V::LANES;
+        let mut p_gapm = V::FloatArray::default();
+        let mut p_mm = V::FloatArray::default();
+        let mut p_mx = V::FloatArray::default();
+        let mut p_xx = V::FloatArray::default();
+        let mut p_my = V::FloatArray::default();
+        let mut p_yy = V::FloatArray::default();
+        let mut distm = V::FloatArray::default();
+        for r in 0..remaining_rows {
+            let row = row_base + r;
+            let i = i[row] & 127;
+            let d = d[row] & 127;
+            let c = c[row] & 127;
+            p_gapm[r] = V::Float::one() - ctx.ph2pr[c as usize];
+            p_mm[r] = ctx.match_to_match_prob(i, d);
+            p_mx[r] = ctx.ph2pr[i as usize];
+            p_xx[r] = ctx.ph2pr[c as usize];
+            p_my[r] = ctx.ph2pr[d as usize];
+            p_yy[r] = ctx.ph2pr[c as usize];
+
+            let q = q[row] & 127;
+            distm[r] = ctx.ph2pr[q as usize];
+        }
+        let p_gapm = V::from_array(p_gapm);
+        let p_mm = V::from_array(p_mm);
+        let p_mx = V::from_array(p_mx);
+        let p_xx = V::from_array(p_xx);
+        let p_my = V::from_array(p_my);
+        let p_yy = V::from_array(p_yy);
+        let distm = V::from_array(distm);
+        let one_distm = V::sub(V::splat(V::Float::one()), distm);
+        let distm = V::div(distm, V::splat(V::Float::from(3)));
+
+        bitmask_vec.init_row(&rs[row_base..], &ctx.convert);
+        let mut begin_d = 0;
+        let max_d = hap.len() + remaining_rows - 1;
+        while begin_d < max_d {
+            let mut bitmask = bitmask_vec.match_col(begin_d / V::MASK_BITS);
+            let num_d = cmp::min(max_d - begin_d, V::MASK_BITS);
+            for d in 0..num_d {
+                let distm_sel = V::blend(distm, one_distm, bitmask);
+                bitmask = V::mask_shift(bitmask);
+                let m_t = V::mul(
+                    V::add(
+                        V::add(V::mul(m_t_2, p_mm), V::mul(x_t_2, p_gapm)),
+                        V::mul(y_t_2, p_gapm),
+                    ),
+                    distm_sel,
+                );
+                let x_t = V::add(V::mul(m_t_1, p_mx), V::mul(x_t_1, p_xx));
+                let y_t = V::add(V::mul(m_t_1_y, p_my), V::mul(y_t_1, p_yy));
+                sum_m = V::add(sum_m, m_t);
+                sum_x = V::add(sum_x, x_t);
+
+                let shift_idx = begin_d + d + V::LANES;
+                m_t_2 = m_t_1;
+                m_t_1 = V::element_shift_in(m_t, &shift_m[shift_idx]);
+                x_t_2 = x_t_1;
+                x_t_1 = V::element_shift_in(x_t, &shift_x[shift_idx]);
+                y_t_2 = V::element_shift_in(y_t_1, &shift_y[shift_idx]);
+                y_t_1 = y_t;
+                m_t_1_y = m_t;
+            }
+            begin_d += V::MASK_BITS;
+        }
+    }
+    let sum = V::add(sum_m, sum_x);
+    let sums = V::to_array(sum);
+    let result = sums[remaining_rows - 1].log10() - ctx.log10_initial_constant;
+    V::restore_flush_zero_mode(mode);
+    result
+}
+
+#[cfg(all(target_arch = "x86_64", not(feature = "c-avx")))]
+mod x86_64_avx {
+    use super::{compute, Forward, ForwardF32, CONTEXT32, CONTEXT64};
+    use crate::vector::{AvxF32x8, AvxF64x4};
+
+    #[target_feature(enable = "avx")]
+    unsafe fn target_forward_f32x8(
+        hap: &[u8],
+        rs: &[u8],
+        q: &[u8],
+        i: &[u8],
+        d: &[u8],
+        c: &[u8],
+    ) -> f32 {
+        let ctx = &CONTEXT32;
+        compute::<AvxF32x8>(ctx, hap, rs, q, i, d, c)
+    }
+
+    pub fn forward_f32x8() -> Option<ForwardF32> {
+        if is_x86_feature_detected!("avx") {
+            fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
+                unsafe { target_forward_f32x8(hap, rs, q, i, d, c) }
+            }
+            Some(f)
+        } else {
+            None
+        }
+    }
+
+    #[target_feature(enable = "avx")]
+    unsafe fn target_forward_f64x4(
+        hap: &[u8],
+        rs: &[u8],
+        q: &[u8],
+        i: &[u8],
+        d: &[u8],
+        c: &[u8],
+    ) -> f64 {
+        let ctx = &CONTEXT64;
+        compute::<AvxF64x4>(ctx, hap, rs, q, i, d, c)
+    }
+
+    pub fn forward_f64x4() -> Option<Forward> {
+        if is_x86_feature_detected!("avx") {
+            fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
+                unsafe { target_forward_f64x4(hap, rs, q, i, d, c) }
+            }
+            Some(f)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", not(feature = "c-avx512"), feature = "nightly"))]
+mod x86_64_avx512 {
+    use super::{compute, Forward, ForwardF32, CONTEXT32, CONTEXT64};
+    use crate::vector::{AvxF32x16, AvxF64x8};
+
+    #[cfg(feature = "nightly")]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn target_forward_f32x16(
+        hap: &[u8],
+        rs: &[u8],
+        q: &[u8],
+        i: &[u8],
+        d: &[u8],
+        c: &[u8],
+    ) -> f32 {
+        let ctx = &CONTEXT32;
+        compute::<AvxF32x16>(ctx, hap, rs, q, i, d, c)
+    }
+
+    #[cfg(feature = "nightly")]
+    pub fn forward_f32x16() -> Option<ForwardF32> {
+        if is_x86_feature_detected!("avx512f") {
+            fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
+                unsafe { target_forward_f32x16(hap, rs, q, i, d, c) }
+            }
+            Some(f)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "nightly")]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn target_forward_f64x8(
+        hap: &[u8],
+        rs: &[u8],
+        q: &[u8],
+        i: &[u8],
+        d: &[u8],
+        c: &[u8],
+    ) -> f64 {
+        let ctx = &CONTEXT64;
+        compute::<AvxF64x8>(ctx, hap, rs, q, i, d, c)
+    }
+
+    #[cfg(feature = "nightly")]
+    pub fn forward_f64x8() -> Option<Forward> {
+        if is_x86_feature_detected!("avx512f") {
+            fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
+                unsafe { target_forward_f64x8(hap, rs, q, i, d, c) }
+            }
+            Some(f)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "c-core"))]
+mod c {
+    #![cfg_attr(not(all(feature = "c-avx", feature = "c-avx512")), allow(unused))]
+    use super::{Forward, ForwardF32};
+    use std::convert::TryInto;
+    use std::os::raw::{c_char, c_int};
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    struct Testcase {
+        rslen: c_int,
+        haplen: c_int,
+        q: *const c_char,
+        i: *const c_char,
+        d: *const c_char,
+        c: *const c_char,
+        hap: *const c_char,
+        rs: *const c_char,
+    }
+
+    impl Testcase {
+        fn new(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> Testcase {
+            let haplen = hap.len();
+            let rslen = rs.len();
+            assert_eq!(rslen, q.len());
+            assert_eq!(rslen, i.len());
+            assert_eq!(rslen, d.len());
+            assert_eq!(rslen, c.len());
+            Testcase {
+                rslen: rslen.try_into().unwrap(),
+                haplen: haplen.try_into().unwrap(),
+                q: q.as_ptr() as *const c_char,
+                i: i.as_ptr() as *const c_char,
+                d: d.as_ptr() as *const c_char,
+                c: c.as_ptr() as *const c_char,
+                hap: hap.as_ptr() as *const c_char,
+                rs: rs.as_ptr() as *const c_char,
+            }
+        }
+    }
+
+    extern "C" {
+        //fn compute_avxd_c(arg1: *mut Testcase) -> f64;
+        fn compute_avxs(arg1: *mut Testcase) -> f32;
+        fn compute_avxd(arg1: *mut Testcase) -> f64;
+        fn compute_avx512s(arg1: *mut Testcase) -> f32;
+        fn compute_avx512d(arg1: *mut Testcase) -> f64;
+        #[link_name = "\u{1}_ZN11ConvertChar15conversionTableE"]
+        static mut ConvertChar_conversionTable: [u8; 255usize];
+    }
+
+    fn convert_char_init() {
+        unsafe {
+            ConvertChar_conversionTable[b'A' as usize] = 0;
+            ConvertChar_conversionTable[b'C' as usize] = 1;
+            ConvertChar_conversionTable[b'T' as usize] = 2;
+            ConvertChar_conversionTable[b'G' as usize] = 3;
+            ConvertChar_conversionTable[b'N' as usize] = 4;
+        }
+    }
+
+    pub fn forward_f32x8() -> Option<ForwardF32> {
+        if !is_x86_feature_detected!("avx") {
+            return None;
+        }
+        convert_char_init();
+        fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
+            let mut tc = Testcase::new(hap, rs, q, i, d, c);
+            unsafe { compute_avxs(&mut tc) }
+        }
+        Some(f)
+    }
+
+    pub fn forward_f64x4() -> Option<Forward> {
+        if !is_x86_feature_detected!("avx") {
+            return None;
+        }
+        convert_char_init();
+        fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
+            let mut tc = Testcase::new(hap, rs, q, i, d, c);
+            unsafe { compute_avxd(&mut tc) }
+        }
+        Some(f)
+    }
+
+    pub fn forward_f32x16() -> Option<ForwardF32> {
+        if !is_x86_feature_detected!("avx512f")
+            || !is_x86_feature_detected!("avx512dq")
+            || !is_x86_feature_detected!("avx512vl")
+        {
+            return None;
+        }
+        convert_char_init();
+        fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f32 {
+            let mut tc = Testcase::new(hap, rs, q, i, d, c);
+            unsafe { compute_avx512s(&mut tc) }
+        }
+        Some(f)
+    }
+
+    pub fn forward_f64x8() -> Option<Forward> {
+        if !is_x86_feature_detected!("avx512f")
+            || !is_x86_feature_detected!("avx512dq")
+            || !is_x86_feature_detected!("avx512vl")
+        {
+            return None;
+        }
+        convert_char_init();
+        fn f(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8]) -> f64 {
+            let mut tc = Testcase::new(hap, rs, q, i, d, c);
+            unsafe { compute_avx512d(&mut tc) }
+        }
+        Some(f)
+    }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,754 @@
+use std::ops;
+
+pub(crate) trait Vector {
+    type Float;
+    type FloatArray: ops::IndexMut<usize, Output = Self::Float> + Default;
+    type FloatVec: Copy;
+    type Mask: Copy
+        + Default
+        + ops::Shl<usize, Output = Self::Mask>
+        + ops::Shr<usize, Output = Self::Mask>
+        + ops::Not<Output = Self::Mask>
+        + ops::BitOr<Output = Self::Mask>
+        + ops::BitOrAssign
+        + From<u8>;
+    type MaskArray: ops::IndexMut<usize, Output = Self::Mask> + Default;
+    type MaskVec: Copy;
+    type IndexArray: ops::IndexMut<usize, Output = u8> + Default;
+    const MASK_BITS: usize;
+    const LANES: usize;
+
+    type Mode;
+    unsafe fn set_flush_zero_mode() -> Self::Mode;
+    unsafe fn restore_flush_zero_mode(mode: Self::Mode);
+
+    // Vector with all elements set to 0.
+    unsafe fn zero() -> Self::FloatVec;
+
+    // Vector with given first element, and remaining elements set to 0.
+    unsafe fn first_element(f: Self::Float) -> Self::FloatVec;
+
+    // Vector with all elements set to given value.
+    unsafe fn splat(f: Self::Float) -> Self::FloatVec;
+
+    fn from_array(a: Self::FloatArray) -> Self::FloatVec;
+    fn to_array(a: Self::FloatVec) -> Self::FloatArray;
+
+    unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    unsafe fn blend(a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec;
+
+    // Shift in a new first element. Shift out the previous last element.
+    unsafe fn element_shift(
+        x: Self::FloatVec,
+        shift_in: *const Self::Float,
+        shift_out: &mut Self::Float,
+    ) -> Self::FloatVec;
+
+    // Shift in a new first element. Discard the previous last element.
+    unsafe fn element_shift_in(x: Self::FloatVec, shift_in: *const Self::Float) -> Self::FloatVec;
+
+    fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec;
+    unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec;
+}
+
+impl Vector for f32 {
+    type Float = f32;
+    type FloatArray = [f32; 1];
+    type FloatVec = f32;
+    type Mask = u32;
+    type MaskArray = [u32; 1];
+    type MaskVec = u32;
+    type IndexArray = [u8; 1];
+    const MASK_BITS: usize = 32;
+    const LANES: usize = 1;
+
+    type Mode = ();
+
+    unsafe fn set_flush_zero_mode() -> Self::Mode {
+        ()
+    }
+
+    unsafe fn restore_flush_zero_mode(_mode: Self::Mode) {}
+
+    unsafe fn zero() -> Self::FloatVec {
+        0.0
+    }
+
+    unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+        f
+    }
+
+    unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+        f
+    }
+
+    fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+        a[0]
+    }
+
+    fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+        [a]
+    }
+
+    unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a + b
+    }
+
+    unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a - b
+    }
+
+    unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a * b
+    }
+
+    unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a / b
+    }
+
+    unsafe fn blend(a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec {
+        if mask & (1 << 31) == 0 {
+            a
+        } else {
+            b
+        }
+    }
+
+    unsafe fn element_shift(
+        x: Self::FloatVec,
+        shift_in: *const Self::Float,
+        shift_out: &mut Self::Float,
+    ) -> Self::FloatVec {
+        *shift_out = x;
+        *shift_in
+    }
+
+    unsafe fn element_shift_in(_x: Self::FloatVec, shift_in: *const Self::Float) -> Self::FloatVec {
+        *shift_in
+    }
+
+    fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+        a[0]
+    }
+
+    unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+        x << 1
+    }
+}
+
+impl Vector for f64 {
+    type Float = f64;
+    type FloatArray = [f64; 1];
+    type FloatVec = f64;
+    type Mask = u32;
+    type MaskArray = [u32; 1];
+    type MaskVec = u32;
+    type IndexArray = [u8; 1];
+    const MASK_BITS: usize = 32;
+    const LANES: usize = 1;
+
+    type Mode = ();
+
+    unsafe fn set_flush_zero_mode() -> Self::Mode {
+        ()
+    }
+
+    unsafe fn restore_flush_zero_mode(_mode: Self::Mode) {}
+
+    unsafe fn zero() -> Self::FloatVec {
+        0.0
+    }
+
+    unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+        f
+    }
+
+    unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+        f
+    }
+
+    fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+        a[0]
+    }
+
+    fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+        [a]
+    }
+
+    unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a + b
+    }
+
+    unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a - b
+    }
+
+    unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a * b
+    }
+
+    unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+        a / b
+    }
+
+    unsafe fn blend(a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec {
+        if mask & (1 << 31) == 0 {
+            a
+        } else {
+            b
+        }
+    }
+
+    unsafe fn element_shift(
+        x: Self::FloatVec,
+        shift_in: *const Self::Float,
+        shift_out: &mut Self::Float,
+    ) -> Self::FloatVec {
+        *shift_out = x;
+        *shift_in
+    }
+
+    unsafe fn element_shift_in(_x: Self::FloatVec, shift_in: *const Self::Float) -> Self::FloatVec {
+        *shift_in
+    }
+
+    fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+        a[0]
+    }
+
+    unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+        x << 1
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", not(feature = "c-avx")))]
+mod x86_64_avx {
+    use super::Vector;
+    use std::arch::x86_64::*;
+    use std::mem;
+
+    pub struct AvxF32x8;
+
+    impl Vector for AvxF32x8 {
+        type Float = f32;
+        type FloatArray = [f32; 8];
+        type FloatVec = __m256;
+        type Mask = u32;
+        type MaskArray = [u32; 8];
+        type MaskVec = __m256;
+        type IndexArray = [u8; 8];
+        const MASK_BITS: usize = 32;
+        const LANES: usize = 8;
+
+        type Mode = u32;
+
+        unsafe fn set_flush_zero_mode() -> Self::Mode {
+            let mode = _MM_GET_FLUSH_ZERO_MODE();
+            _MM_SET_FLUSH_ZERO_MODE(0x8000);
+            mode
+        }
+
+        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
+            _MM_SET_FLUSH_ZERO_MODE(mode);
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn zero() -> Self::FloatVec {
+            _mm256_setzero_ps()
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+            _mm256_set_ps(0., 0., 0., 0., 0., 0., 0., f)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+            _mm256_set1_ps(f)
+        }
+
+        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_add_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_sub_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_mul_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_div_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn blend(
+            a: Self::FloatVec,
+            b: Self::FloatVec,
+            mask: Self::MaskVec,
+        ) -> Self::FloatVec {
+            _mm256_blendv_ps(a, b, mask)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn element_shift(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+            shift_out: &mut Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let y: [f32; 8] = mem::transmute(x);
+            *shift_out = y[7];
+            */
+            *shift_out = mem::transmute(_mm_extract_ps::<3>(_mm256_extractf128_ps::<1>(x)));
+            Self::element_shift_in(x, shift_in)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn element_shift_in(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let x: [f32; 8] = mem::transmute(x);
+            mem::transmute([*shift_in, x[0], x[1], x[2], x[3], x[4], x[5], x[6]]
+            */
+
+            // Rotate the lanes, then replace the lowest lanes.
+            let x = _mm256_permute_ps::<0b10_01_00_11>(x);
+            let mut x: [__m128; 2] = mem::transmute(x);
+            x[1] = _mm_move_ss(x[1], x[0]);
+            x[0] = _mm_move_ss(x[0], _mm_load_ss(shift_in));
+            mem::transmute(x)
+
+            /* TODO
+             * The above code currently compiles into a permute + blend.
+             * However, if we try to do that explicity (as shown below),
+             * the compiler converts it into something slower.
+             */
+            /*
+            let x = _mm256_permute_ps::<0b10_01_00_11>(x);
+            let low = mem::transmute([_mm_load_ss(shift_in), _mm256_extractf128_ps::<0>(x)]);
+            _mm256_blend_ps::<0x11>(x, low)
+            */
+        }
+
+        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+            // TODO: _mm256_add_epi64(x, x) is a small improvement but requires avx2
+            let mut x: [__m128i; 2] = mem::transmute(x);
+            x[0] = _mm_slli_epi64::<1>(x[0]);
+            x[1] = _mm_slli_epi64::<1>(x[1]);
+            mem::transmute(x)
+        }
+    }
+
+    pub struct AvxF64x4;
+
+    impl Vector for AvxF64x4 {
+        type Float = f64;
+        type FloatArray = [f64; 4];
+        type FloatVec = __m256d;
+        type Mask = u64;
+        type MaskArray = [u64; 4];
+        type MaskVec = __m256d;
+        type IndexArray = [u8; 4];
+        const MASK_BITS: usize = 64;
+        const LANES: usize = 4;
+
+        type Mode = u32;
+
+        unsafe fn set_flush_zero_mode() -> Self::Mode {
+            let mode = _MM_GET_FLUSH_ZERO_MODE();
+            _MM_SET_FLUSH_ZERO_MODE(0x8000);
+            mode
+        }
+
+        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
+            _MM_SET_FLUSH_ZERO_MODE(mode);
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn zero() -> Self::FloatVec {
+            _mm256_setzero_pd()
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+            _mm256_set_pd(0., 0., 0., f)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+            _mm256_set1_pd(f)
+        }
+
+        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_add_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_sub_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_mul_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm256_div_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn blend(
+            a: Self::FloatVec,
+            b: Self::FloatVec,
+            mask: Self::MaskVec,
+        ) -> Self::FloatVec {
+            _mm256_blendv_pd(a, b, mask)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn element_shift(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+            shift_out: &mut Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let y: [f64; 4] = mem::transmute(x);
+            *shift_out = y[3];
+            */
+            *shift_out = mem::transmute(_mm_extract_epi64::<1>(mem::transmute(
+                _mm256_extractf128_pd::<1>(x),
+            )));
+            Self::element_shift_in(x, shift_in)
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn element_shift_in(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let x: [f64; 4] = mem::transmute(x);
+            let x: [f64; 4] = [*shift_in, x[0], x[1], x[2]];
+            mem::transmute(x)
+            */
+
+            // Rotate the lanes, then replace the lowest lanes.
+            let x = _mm256_permute_pd::<0b01_01>(x);
+            let mut x: [__m128d; 2] = mem::transmute(x);
+            x[1] = _mm_move_sd(x[1], x[0]);
+            x[0] = _mm_move_sd(x[0], _mm_load_sd(shift_in));
+            mem::transmute(x)
+
+            /* Blend is slower in this case:
+            let x = _mm256_permute_pd::<0b01_01>(x);
+            let low = mem::transmute([_mm256_extractf128_pd::<0>(x), _mm_load_sd(shift_in)]);
+            _mm256_blend_pd::<0b01_01>(x, low)
+            */
+        }
+
+        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx")]
+        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+            let mut x: [__m128i; 2] = mem::transmute(x);
+            x[0] = _mm_slli_epi64::<1>(x[0]);
+            x[1] = _mm_slli_epi64::<1>(x[1]);
+            mem::transmute(x)
+        }
+    }
+}
+#[cfg(all(target_arch = "x86_64", not(feature = "c-avx")))]
+pub(crate) use x86_64_avx::*;
+
+#[cfg(all(target_arch = "x86_64", not(feature = "c-avx512"), feature = "nightly"))]
+mod x86_64_avx512 {
+    use super::Vector;
+    use std::arch::x86_64::*;
+    use std::mem;
+
+    #[cfg(feature = "nightly")]
+    pub struct AvxF32x16;
+
+    #[cfg(feature = "nightly")]
+    impl Vector for AvxF32x16 {
+        type Float = f32;
+        type FloatArray = [f32; 16];
+        type FloatVec = __m512;
+        type Mask = u32;
+        type MaskArray = [u32; 16];
+        type MaskVec = __m512i;
+        type IndexArray = [u8; 16];
+        const MASK_BITS: usize = 32;
+        const LANES: usize = 16;
+
+        type Mode = u32;
+
+        unsafe fn set_flush_zero_mode() -> Self::Mode {
+            let mode = _MM_GET_FLUSH_ZERO_MODE();
+            _MM_SET_FLUSH_ZERO_MODE(0x8000);
+            mode
+        }
+
+        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
+            _MM_SET_FLUSH_ZERO_MODE(mode);
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn zero() -> Self::FloatVec {
+            _mm512_setzero_ps()
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+            _mm512_set_ps(
+                0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., f,
+            )
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+            _mm512_set1_ps(f)
+        }
+
+        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_add_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_sub_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_mul_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_div_ps(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn blend(
+            a: Self::FloatVec,
+            b: Self::FloatVec,
+            mask: Self::MaskVec,
+        ) -> Self::FloatVec {
+            let bit = _mm512_set1_epi32(1 << 31);
+            let mask = _mm512_test_epi32_mask(mask, bit);
+            _mm512_mask_blend_ps(mask, a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn element_shift(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+            shift_out: &mut Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let y: [f32; 16] = mem::transmute(x);
+            *shift_out = y[15];
+            */
+            *shift_out = mem::transmute(_mm_extract_ps::<3>(_mm512_extractf32x4_ps::<3>(x)));
+            Self::element_shift_in(x, shift_in)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn element_shift_in(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let x: [f32; 16] = mem::transmute(x);
+            let x: [f32; 16] = [*shift_in, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14]];
+            mem::transmute(x)
+            */
+            let shift_in = _mm512_castps128_ps512(_mm_load_ss(shift_in));
+            let index = mem::transmute([16u32, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+            _mm512_mask_permutex2var_ps(x, !0, index, shift_in)
+        }
+
+        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+            _mm512_slli_epi32::<1>(x)
+        }
+    }
+
+    #[cfg(feature = "nightly")]
+    pub struct AvxF64x8;
+
+    #[cfg(feature = "nightly")]
+    impl Vector for AvxF64x8 {
+        type Float = f64;
+        type FloatArray = [f64; 8];
+        type FloatVec = __m512d;
+        type Mask = u64;
+        type MaskArray = [u64; 8];
+        type MaskVec = __m512i;
+        type IndexArray = [u8; 8];
+        const MASK_BITS: usize = 64;
+        const LANES: usize = 8;
+
+        type Mode = u32;
+
+        unsafe fn set_flush_zero_mode() -> Self::Mode {
+            let mode = _MM_GET_FLUSH_ZERO_MODE();
+            _MM_SET_FLUSH_ZERO_MODE(0x8000);
+            mode
+        }
+
+        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
+            _MM_SET_FLUSH_ZERO_MODE(mode);
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn zero() -> Self::FloatVec {
+            _mm512_setzero_pd()
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+            _mm512_set_pd(0., 0., 0., 0., 0., 0., 0., f)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+            _mm512_set1_pd(f)
+        }
+
+        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_add_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_sub_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_mul_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            _mm512_div_pd(a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn blend(
+            a: Self::FloatVec,
+            b: Self::FloatVec,
+            mask: Self::MaskVec,
+        ) -> Self::FloatVec {
+            let bit = _mm512_set1_epi64(1 << 63);
+            let mask = _mm512_test_epi64_mask(mask, bit);
+            _mm512_mask_blend_pd(mask, a, b)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn element_shift(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+            shift_out: &mut Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let y: [f64; 8] = mem::transmute(x);
+            *shift_out = y[7];
+            */
+            // TODO: missing _mm512_extractf64x2_pd?
+            _mm_storeh_pd(
+                shift_out,
+                mem::transmute(_mm512_extractf32x4_ps::<3>(mem::transmute(x))),
+            );
+            Self::element_shift_in(x, shift_in)
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn element_shift_in(
+            x: Self::FloatVec,
+            shift_in: *const Self::Float,
+        ) -> Self::FloatVec {
+            /*
+            let x: [f64; 8] = mem::transmute(x);
+            let x: [f64; 8] = [*shift_in, x[0], x[1], x[2], x[3], x[4], x[5], x[6]];
+            mem::transmute(x)
+            */
+            let shift_in = _mm512_castpd128_pd512(_mm_load_sd(shift_in));
+            let index = mem::transmute([8u64, 0, 1, 2, 3, 4, 5, 6]);
+            _mm512_mask_permutex2var_pd(x, !0, index, shift_in)
+        }
+
+        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+            unsafe { mem::transmute(a) }
+        }
+
+        #[target_feature(enable = "avx512f")]
+        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+            _mm512_slli_epi64::<1>(x)
+        }
+    }
+}
+#[cfg(all(target_arch = "x86_64", not(feature = "c-avx512"), feature = "nightly"))]
+pub(crate) use x86_64_avx512::*;

--- a/tests/pairhmm.rs
+++ b/tests/pairhmm.rs
@@ -4,57 +4,46 @@ use std::io::{BufRead, BufReader};
 
 fn test_one(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8], expected: f64) {
     println!("expected: {}", expected);
-    if let Some(f) = gkl::pairhmm::forward_f32_avx() {
+    if let Some(f) = gkl::pairhmm::forward_f32x8() {
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("f32x8 {}", fp);
         assert!((fp as f64 - expected).abs() < 1e-5);
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f64_avx() {
+    if let Some(f) = gkl::pairhmm::forward_f64x4() {
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("f64x4 {}", fp);
         assert!((fp - expected).abs() < 1e-5);
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f32_avx512() {
+    if let Some(f) = gkl::pairhmm::forward_f32x16() {
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("f32x16 {}", fp);
         assert!((fp as f64 - expected).abs() < 1e-5);
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f64_avx512() {
+    if let Some(f) = gkl::pairhmm::forward_f64x8() {
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("f64x8 {}", fp);
         assert!((fp - expected).abs() < 1e-5);
     }
 
     if let Some(f) = gkl::pairhmm::forward_f32() {
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("f32 any {}", fp);
         assert!((fp as f64 - expected).abs() < 1e-5);
     }
 
     if let Some(f) = gkl::pairhmm::forward_f64() {
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("f64 any {}", fp);
         assert!((fp - expected).abs() < 1e-5);
     }
 
-    if let Some(f) = gkl::pairhmm::forward_avx() {
+    {
+        let f = gkl::pairhmm::forward;
         let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
-        assert!((fp as f64 - expected).abs() < 1e-5);
-    }
-
-    if let Some(f) = gkl::pairhmm::forward_avx512() {
-        let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
-        assert!((fp - expected).abs() < 1e-5);
-    }
-
-    if let Some(f) = gkl::pairhmm::forward() {
-        let fp = f(hap, rs, q, i, d, c);
-        println!("{}", fp);
+        println!("any {}", fp);
         assert!((fp as f64 - expected).abs() < 1e-5);
     }
 }

--- a/tests/pairhmm.rs
+++ b/tests/pairhmm.rs
@@ -4,22 +4,37 @@ use std::io::{BufRead, BufReader};
 
 fn test_one(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8], expected: f64) {
     println!("expected: {}", expected);
+
+    {
+        let f = gkl::pairhmm::forward_f32x1();
+        let fp = f(hap, rs, q, i, d, c);
+        println!("f32x1 {}", fp);
+        assert!((fp as f64 - expected).abs() < 1e-5);
+    }
+
     if let Some(f) = gkl::pairhmm::forward_f32x8() {
         let fp = f(hap, rs, q, i, d, c);
         println!("f32x8 {}", fp);
         assert!((fp as f64 - expected).abs() < 1e-5);
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f64x4() {
-        let fp = f(hap, rs, q, i, d, c);
-        println!("f64x4 {}", fp);
-        assert!((fp - expected).abs() < 1e-5);
-    }
-
     if let Some(f) = gkl::pairhmm::forward_f32x16() {
         let fp = f(hap, rs, q, i, d, c);
         println!("f32x16 {}", fp);
         assert!((fp as f64 - expected).abs() < 1e-5);
+    }
+
+    {
+        let f = gkl::pairhmm::forward_f64x1();
+        let fp = f(hap, rs, q, i, d, c);
+        println!("f64x1 {}", fp);
+        assert!((fp - expected).abs() < 1e-5);
+    }
+
+    if let Some(f) = gkl::pairhmm::forward_f64x4() {
+        let fp = f(hap, rs, q, i, d, c);
+        println!("f64x4 {}", fp);
+        assert!((fp - expected).abs() < 1e-5);
     }
 
     if let Some(f) = gkl::pairhmm::forward_f64x8() {
@@ -34,7 +49,8 @@ fn test_one(hap: &[u8], rs: &[u8], q: &[u8], i: &[u8], d: &[u8], c: &[u8], expec
         assert!((fp as f64 - expected).abs() < 1e-5);
     }
 
-    if let Some(f) = gkl::pairhmm::forward_f64() {
+    {
+        let f = gkl::pairhmm::forward_f64();
         let fp = f(hap, rs, q, i, d, c);
         println!("f64 any {}", fp);
         assert!((fp - expected).abs() < 1e-5);


### PR DESCRIPTION
The following are supported:
- use rust for AVX, and disable AVX-512: default features
- use rust for AVX and AVX-512: `--features nightly`
- use rust for AVX and C++ for AVX-512: `--features c-avx512`
- use C++ for AVX and AVX-512: `--features c`

Improvement from `--features c` to `--features nightly`:

```
forward_f32x8           time:   [32.699 ms 32.709 ms 32.722 ms]
                        change: [-7.6401% -7.5967% -7.5480%] (p = 0.00 < 0.05)
                        Performance has improved.

forward_f32x16          time:   [16.582 ms 16.588 ms 16.594 ms]
                        change: [-10.186% -10.145% -10.100%] (p = 0.00 < 0.05)
                        Performance has improved.

forward_f64x4           time:   [48.538 ms 48.552 ms 48.568 ms]
                        change: [-36.174% -36.121% -36.078%] (p = 0.00 < 0.05)
                        Performance has improved.

forward_f64x8           time:   [26.147 ms 26.270 ms 26.401 ms]
                        change: [-17.639% -17.288% -16.925%] (p = 0.00 < 0.05)
                        Performance has improved.
```