### PR TITLE
pairhmm: avoid `unsafe compute`

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,7 @@
 use std::ops;
 
-pub(crate) trait Vector {
+/// A target specific implementation of vector operations.
+pub(crate) trait Vector: Copy {
     type Float;
     type FloatArray: ops::IndexMut<usize, Output = Self::Float> + Default;
     type FloatVec: Copy;
@@ -19,42 +20,41 @@ pub(crate) trait Vector {
     const LANES: usize;
 
     type Mode;
-    unsafe fn set_flush_zero_mode() -> Self::Mode;
-    unsafe fn restore_flush_zero_mode(mode: Self::Mode);
+    fn set_flush_zero_mode(self) -> Self::Mode;
+    fn restore_flush_zero_mode(self, mode: Self::Mode);
 
     // Vector with all elements set to 0.
-    unsafe fn zero() -> Self::FloatVec;
+    fn zero(self) -> Self::FloatVec;
 
     // Vector with given first element, and remaining elements set to 0.
-    unsafe fn first_element(f: Self::Float) -> Self::FloatVec;
+    fn first_element(self, f: Self::Float) -> Self::FloatVec;
 
     // Vector with all elements set to given value.
-    unsafe fn splat(f: Self::Float) -> Self::FloatVec;
+    fn splat(self, f: Self::Float) -> Self::FloatVec;
 
-    fn from_array(a: Self::FloatArray) -> Self::FloatVec;
-    fn to_array(a: Self::FloatVec) -> Self::FloatArray;
+    fn from_array(self, a: Self::FloatArray) -> Self::FloatVec;
+    fn to_array(self, a: Self::FloatVec) -> Self::FloatArray;
 
-    unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
-    unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
-    unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
-    unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
-    unsafe fn blend(a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec;
+    fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec;
+    fn blend(self, a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec;
 
-    // Shift in a new first element. Shift out the previous last element.
-    unsafe fn element_shift(
-        x: Self::FloatVec,
-        shift_in: *const Self::Float,
-        shift_out: &mut Self::Float,
-    ) -> Self::FloatVec;
+    // Shift out the previous last element.
+    fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float);
 
-    // Shift in a new first element. Discard the previous last element.
-    unsafe fn element_shift_in(x: Self::FloatVec, shift_in: *const Self::Float) -> Self::FloatVec;
+    // Shift in a new first element.
+    fn element_shift_in(self, x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec;
 
-    fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec;
-    unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec;
+    fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec;
+    fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec;
 }
 
-impl Vector for f32 {
+#[derive(Clone, Copy)]
+pub(crate) struct F32x1;
+
+impl Vector for F32x1 {
     type Float = f32;
     type FloatArray = [f32; 1];
     type FloatVec = f32;
@@ -67,49 +67,61 @@ impl Vector for f32 {
 
     type Mode = ();
 
-    unsafe fn set_flush_zero_mode() -> Self::Mode {
+    #[inline]
+    fn set_flush_zero_mode(self) -> Self::Mode {
         ()
     }
 
-    unsafe fn restore_flush_zero_mode(_mode: Self::Mode) {}
+    #[inline]
+    fn restore_flush_zero_mode(self, _mode: Self::Mode) {}
 
-    unsafe fn zero() -> Self::FloatVec {
+    #[inline]
+    fn zero(self) -> Self::FloatVec {
         0.0
     }
 
-    unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+    #[inline]
+    fn first_element(self, f: Self::Float) -> Self::FloatVec {
         f
     }
 
-    unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+    #[inline]
+    fn splat(self, f: Self::Float) -> Self::FloatVec {
         f
     }
 
-    fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+    #[inline]
+    fn from_array(self, a: Self::FloatArray) -> Self::FloatVec {
         a[0]
     }
 
-    fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+    #[inline]
+    fn to_array(self, a: Self::FloatVec) -> Self::FloatArray {
         [a]
     }
 
-    unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a + b
     }
 
-    unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a - b
     }
 
-    unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a * b
     }
 
-    unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a / b
     }
 
-    unsafe fn blend(a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec {
+    #[inline]
+    fn blend(self, a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec {
         if mask & (1 << 31) == 0 {
             a
         } else {
@@ -117,29 +129,31 @@ impl Vector for f32 {
         }
     }
 
-    unsafe fn element_shift(
-        x: Self::FloatVec,
-        shift_in: *const Self::Float,
-        shift_out: &mut Self::Float,
-    ) -> Self::FloatVec {
+    #[inline]
+    fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float) {
         *shift_out = x;
+    }
+
+    #[inline]
+    fn element_shift_in(self, _x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec {
         *shift_in
     }
 
-    unsafe fn element_shift_in(_x: Self::FloatVec, shift_in: *const Self::Float) -> Self::FloatVec {
-        *shift_in
-    }
-
-    fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+    #[inline]
+    fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec {
         a[0]
     }
 
-    unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+    #[inline]
+    fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec {
         x << 1
     }
 }
 
-impl Vector for f64 {
+#[derive(Clone, Copy)]
+pub(crate) struct F64x1;
+
+impl Vector for F64x1 {
     type Float = f64;
     type FloatArray = [f64; 1];
     type FloatVec = f64;
@@ -152,49 +166,61 @@ impl Vector for f64 {
 
     type Mode = ();
 
-    unsafe fn set_flush_zero_mode() -> Self::Mode {
+    #[inline]
+    fn set_flush_zero_mode(self) -> Self::Mode {
         ()
     }
 
-    unsafe fn restore_flush_zero_mode(_mode: Self::Mode) {}
+    #[inline]
+    fn restore_flush_zero_mode(self, _mode: Self::Mode) {}
 
-    unsafe fn zero() -> Self::FloatVec {
+    #[inline]
+    fn zero(self) -> Self::FloatVec {
         0.0
     }
 
-    unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
+    #[inline]
+    fn first_element(self, f: Self::Float) -> Self::FloatVec {
         f
     }
 
-    unsafe fn splat(f: Self::Float) -> Self::FloatVec {
+    #[inline]
+    fn splat(self, f: Self::Float) -> Self::FloatVec {
         f
     }
 
-    fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+    #[inline]
+    fn from_array(self, a: Self::FloatArray) -> Self::FloatVec {
         a[0]
     }
 
-    fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+    #[inline]
+    fn to_array(self, a: Self::FloatVec) -> Self::FloatArray {
         [a]
     }
 
-    unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a + b
     }
 
-    unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a - b
     }
 
-    unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a * b
     }
 
-    unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+    #[inline]
+    fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
         a / b
     }
 
-    unsafe fn blend(a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec {
+    #[inline]
+    fn blend(self, a: Self::FloatVec, b: Self::FloatVec, mask: Self::MaskVec) -> Self::FloatVec {
         if mask & (1 << 31) == 0 {
             a
         } else {
@@ -202,24 +228,23 @@ impl Vector for f64 {
         }
     }
 
-    unsafe fn element_shift(
-        x: Self::FloatVec,
-        shift_in: *const Self::Float,
-        shift_out: &mut Self::Float,
-    ) -> Self::FloatVec {
+    #[inline]
+    fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float) {
         *shift_out = x;
+    }
+
+    #[inline]
+    fn element_shift_in(self, _x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec {
         *shift_in
     }
 
-    unsafe fn element_shift_in(_x: Self::FloatVec, shift_in: *const Self::Float) -> Self::FloatVec {
-        *shift_in
-    }
-
-    fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+    #[inline]
+    fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec {
         a[0]
     }
 
-    unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+    #[inline]
+    fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec {
         x << 1
     }
 }
@@ -230,7 +255,24 @@ mod x86_64_avx {
     use std::arch::x86_64::*;
     use std::mem;
 
-    pub struct AvxF32x8;
+    #[derive(Clone, Copy)]
+    pub struct AvxF32x8(());
+
+    impl AvxF32x8 {
+        #[inline]
+        pub fn new() -> Option<Self> {
+            if is_x86_feature_detected!("avx") {
+                Some(AvxF32x8(()))
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        pub unsafe fn new_unchecked() -> Self {
+            AvxF32x8(())
+        }
+    }
 
     impl Vector for AvxF32x8 {
         type Float = f32;
@@ -245,98 +287,103 @@ mod x86_64_avx {
 
         type Mode = u32;
 
-        unsafe fn set_flush_zero_mode() -> Self::Mode {
-            let mode = _MM_GET_FLUSH_ZERO_MODE();
-            _MM_SET_FLUSH_ZERO_MODE(0x8000);
-            mode
+        #[inline]
+        fn set_flush_zero_mode(self) -> Self::Mode {
+            unsafe {
+                let mode = _MM_GET_FLUSH_ZERO_MODE();
+                _MM_SET_FLUSH_ZERO_MODE(0x8000);
+                mode
+            }
         }
 
-        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
-            _MM_SET_FLUSH_ZERO_MODE(mode);
+        #[inline]
+        fn restore_flush_zero_mode(self, mode: Self::Mode) {
+            unsafe {
+                _MM_SET_FLUSH_ZERO_MODE(mode);
+            }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn zero() -> Self::FloatVec {
-            _mm256_setzero_ps()
+        #[inline]
+        fn zero(self) -> Self::FloatVec {
+            unsafe { _mm256_setzero_ps() }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
-            _mm256_set_ps(0., 0., 0., 0., 0., 0., 0., f)
+        #[inline]
+        fn first_element(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm256_set_ps(0., 0., 0., 0., 0., 0., 0., f) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
-            _mm256_set1_ps(f)
+        #[inline]
+        fn splat(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm256_set1_ps(f) }
         }
 
-        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+        #[inline]
+        fn from_array(self, a: Self::FloatArray) -> Self::FloatVec {
             unsafe { mem::transmute(a) }
         }
 
-        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+        #[inline]
+        fn to_array(self, a: Self::FloatVec) -> Self::FloatArray {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_add_ps(a, b)
+        #[inline]
+        fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_add_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_sub_ps(a, b)
+        #[inline]
+        fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_sub_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_mul_ps(a, b)
+        #[inline]
+        fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_mul_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_div_ps(a, b)
+        #[inline]
+        fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_div_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn blend(
+        #[inline]
+        fn blend(
+            self,
             a: Self::FloatVec,
             b: Self::FloatVec,
             mask: Self::MaskVec,
         ) -> Self::FloatVec {
-            _mm256_blendv_ps(a, b, mask)
+            unsafe { _mm256_blendv_ps(a, b, mask) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn element_shift(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-            shift_out: &mut Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float) {
             /*
             let y: [f32; 8] = mem::transmute(x);
             *shift_out = y[7];
             */
-            *shift_out = mem::transmute(_mm_extract_ps::<3>(_mm256_extractf128_ps::<1>(x)));
-            Self::element_shift_in(x, shift_in)
+            unsafe {
+                *shift_out = mem::transmute(_mm_extract_ps::<3>(_mm256_extractf128_ps::<1>(x)));
+            }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn element_shift_in(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_in(self, x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec {
             /*
             let x: [f32; 8] = mem::transmute(x);
             mem::transmute([*shift_in, x[0], x[1], x[2], x[3], x[4], x[5], x[6]]
             */
 
             // Rotate the lanes, then replace the lowest lanes.
-            let x = _mm256_permute_ps::<0b10_01_00_11>(x);
-            let mut x: [__m128; 2] = mem::transmute(x);
-            x[1] = _mm_move_ss(x[1], x[0]);
-            x[0] = _mm_move_ss(x[0], _mm_load_ss(shift_in));
-            mem::transmute(x)
+            unsafe {
+                let x = _mm256_permute_ps::<0b10_01_00_11>(x);
+                let mut x: [__m128; 2] = mem::transmute(x);
+                x[1] = _mm_move_ss(x[1], x[0]);
+                x[0] = _mm_move_ss(x[0], _mm_load_ss(shift_in));
+                mem::transmute(x)
+            }
 
             /* TODO
              * The above code currently compiles into a permute + blend.
@@ -350,21 +397,41 @@ mod x86_64_avx {
             */
         }
 
-        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+        #[inline]
+        fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
+        #[inline]
+        fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec {
             // TODO: _mm256_add_epi64(x, x) is a small improvement but requires avx2
-            let mut x: [__m128i; 2] = mem::transmute(x);
-            x[0] = _mm_slli_epi64::<1>(x[0]);
-            x[1] = _mm_slli_epi64::<1>(x[1]);
-            mem::transmute(x)
+            unsafe {
+                let mut x: [__m128i; 2] = mem::transmute(x);
+                x[0] = _mm_slli_epi64::<1>(x[0]);
+                x[1] = _mm_slli_epi64::<1>(x[1]);
+                mem::transmute(x)
+            }
         }
     }
 
-    pub struct AvxF64x4;
+    #[derive(Clone, Copy)]
+    pub struct AvxF64x4(());
+
+    impl AvxF64x4 {
+        #[inline]
+        pub fn new() -> Option<Self> {
+            if is_x86_feature_detected!("avx") {
+                Some(AvxF64x4(()))
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        pub fn new_unchecked() -> Self {
+            AvxF64x4(())
+        }
+    }
 
     impl Vector for AvxF64x4 {
         type Float = f64;
@@ -379,89 +446,92 @@ mod x86_64_avx {
 
         type Mode = u32;
 
-        unsafe fn set_flush_zero_mode() -> Self::Mode {
-            let mode = _MM_GET_FLUSH_ZERO_MODE();
-            _MM_SET_FLUSH_ZERO_MODE(0x8000);
-            mode
+        #[inline]
+        fn set_flush_zero_mode(self) -> Self::Mode {
+            unsafe {
+                let mode = _MM_GET_FLUSH_ZERO_MODE();
+                _MM_SET_FLUSH_ZERO_MODE(0x8000);
+                mode
+            }
         }
 
-        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
-            _MM_SET_FLUSH_ZERO_MODE(mode);
+        #[inline]
+        fn restore_flush_zero_mode(self, mode: Self::Mode) {
+            unsafe {
+                _MM_SET_FLUSH_ZERO_MODE(mode);
+            }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn zero() -> Self::FloatVec {
-            _mm256_setzero_pd()
+        #[inline]
+        fn zero(self) -> Self::FloatVec {
+            unsafe { _mm256_setzero_pd() }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
-            _mm256_set_pd(0., 0., 0., f)
+        #[inline]
+        fn first_element(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm256_set_pd(0., 0., 0., f) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
-            _mm256_set1_pd(f)
+        #[inline]
+        fn splat(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm256_set1_pd(f) }
         }
 
-        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+        #[inline]
+        fn from_array(self, a: Self::FloatArray) -> Self::FloatVec {
             unsafe { mem::transmute(a) }
         }
 
-        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+        #[inline]
+        fn to_array(self, a: Self::FloatVec) -> Self::FloatArray {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_add_pd(a, b)
+        #[inline]
+        fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_add_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_sub_pd(a, b)
+        #[inline]
+        fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_sub_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_mul_pd(a, b)
+        #[inline]
+        fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_mul_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm256_div_pd(a, b)
+        #[inline]
+        fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm256_div_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn blend(
+        #[inline]
+        fn blend(
+            self,
             a: Self::FloatVec,
             b: Self::FloatVec,
             mask: Self::MaskVec,
         ) -> Self::FloatVec {
-            _mm256_blendv_pd(a, b, mask)
+            unsafe { _mm256_blendv_pd(a, b, mask) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn element_shift(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-            shift_out: &mut Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float) {
             /*
             let y: [f64; 4] = mem::transmute(x);
             *shift_out = y[3];
             */
-            *shift_out = mem::transmute(_mm_extract_epi64::<1>(mem::transmute(
-                _mm256_extractf128_pd::<1>(x),
-            )));
-            Self::element_shift_in(x, shift_in)
+            unsafe {
+                *shift_out = mem::transmute(_mm_extract_epi64::<1>(mem::transmute(
+                    _mm256_extractf128_pd::<1>(x),
+                )));
+            }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn element_shift_in(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_in(self, x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec {
             /*
             let x: [f64; 4] = mem::transmute(x);
             let x: [f64; 4] = [*shift_in, x[0], x[1], x[2]];
@@ -469,11 +539,13 @@ mod x86_64_avx {
             */
 
             // Rotate the lanes, then replace the lowest lanes.
-            let x = _mm256_permute_pd::<0b01_01>(x);
-            let mut x: [__m128d; 2] = mem::transmute(x);
-            x[1] = _mm_move_sd(x[1], x[0]);
-            x[0] = _mm_move_sd(x[0], _mm_load_sd(shift_in));
-            mem::transmute(x)
+            unsafe {
+                let x = _mm256_permute_pd::<0b01_01>(x);
+                let mut x: [__m128d; 2] = mem::transmute(x);
+                x[1] = _mm_move_sd(x[1], x[0]);
+                x[0] = _mm_move_sd(x[0], _mm_load_sd(shift_in));
+                mem::transmute(x)
+            }
 
             /* Blend is slower in this case:
             let x = _mm256_permute_pd::<0b01_01>(x);
@@ -482,16 +554,19 @@ mod x86_64_avx {
             */
         }
 
-        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+        #[inline]
+        fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx")]
-        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
-            let mut x: [__m128i; 2] = mem::transmute(x);
-            x[0] = _mm_slli_epi64::<1>(x[0]);
-            x[1] = _mm_slli_epi64::<1>(x[1]);
-            mem::transmute(x)
+        #[inline]
+        fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec {
+            unsafe {
+                let mut x: [__m128i; 2] = mem::transmute(x);
+                x[0] = _mm_slli_epi64::<1>(x[0]);
+                x[1] = _mm_slli_epi64::<1>(x[1]);
+                mem::transmute(x)
+            }
         }
     }
 }
@@ -504,10 +579,25 @@ mod x86_64_avx512 {
     use std::arch::x86_64::*;
     use std::mem;
 
-    #[cfg(feature = "nightly")]
-    pub struct AvxF32x16;
+    #[derive(Clone, Copy)]
+    pub struct AvxF32x16(());
 
-    #[cfg(feature = "nightly")]
+    impl AvxF32x16 {
+        #[inline]
+        pub fn new() -> Option<Self> {
+            if is_x86_feature_detected!("avx512f") {
+                Some(AvxF32x16(()))
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        pub fn new_unchecked() -> Self {
+            AvxF32x16(())
+        }
+    }
+
     impl Vector for AvxF32x16 {
         type Float = f32;
         type FloatArray = [f32; 16];
@@ -521,115 +611,141 @@ mod x86_64_avx512 {
 
         type Mode = u32;
 
-        unsafe fn set_flush_zero_mode() -> Self::Mode {
-            let mode = _MM_GET_FLUSH_ZERO_MODE();
-            _MM_SET_FLUSH_ZERO_MODE(0x8000);
-            mode
+        #[inline]
+        fn set_flush_zero_mode(self) -> Self::Mode {
+            unsafe {
+                let mode = _MM_GET_FLUSH_ZERO_MODE();
+                _MM_SET_FLUSH_ZERO_MODE(0x8000);
+                mode
+            }
         }
 
-        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
-            _MM_SET_FLUSH_ZERO_MODE(mode);
+        #[inline]
+        fn restore_flush_zero_mode(self, mode: Self::Mode) {
+            unsafe {
+                _MM_SET_FLUSH_ZERO_MODE(mode);
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn zero() -> Self::FloatVec {
-            _mm512_setzero_ps()
+        #[inline]
+        fn zero(self) -> Self::FloatVec {
+            unsafe { _mm512_setzero_ps() }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
-            _mm512_set_ps(
-                0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., f,
-            )
+        #[inline]
+        fn first_element(self, f: Self::Float) -> Self::FloatVec {
+            unsafe {
+                _mm512_set_ps(
+                    0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., f,
+                )
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
-            _mm512_set1_ps(f)
+        #[inline]
+        fn splat(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm512_set1_ps(f) }
         }
 
-        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+        #[inline]
+        fn from_array(self, a: Self::FloatArray) -> Self::FloatVec {
             unsafe { mem::transmute(a) }
         }
 
-        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+        #[inline]
+        fn to_array(self, a: Self::FloatVec) -> Self::FloatArray {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_add_ps(a, b)
+        #[inline]
+        fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_add_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_sub_ps(a, b)
+        #[inline]
+        fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_sub_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_mul_ps(a, b)
+        #[inline]
+        fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_mul_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_div_ps(a, b)
+        #[inline]
+        fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_div_ps(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn blend(
+        #[inline]
+        fn blend(
+            self,
             a: Self::FloatVec,
             b: Self::FloatVec,
             mask: Self::MaskVec,
         ) -> Self::FloatVec {
-            let bit = _mm512_set1_epi32(1 << 31);
-            let mask = _mm512_test_epi32_mask(mask, bit);
-            _mm512_mask_blend_ps(mask, a, b)
+            unsafe {
+                let bit = _mm512_set1_epi32(1 << 31);
+                let mask = _mm512_test_epi32_mask(mask, bit);
+                _mm512_mask_blend_ps(mask, a, b)
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn element_shift(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-            shift_out: &mut Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float) {
             /*
             let y: [f32; 16] = mem::transmute(x);
             *shift_out = y[15];
             */
-            *shift_out = mem::transmute(_mm_extract_ps::<3>(_mm512_extractf32x4_ps::<3>(x)));
-            Self::element_shift_in(x, shift_in)
+            unsafe {
+                *shift_out = mem::transmute(_mm_extract_ps::<3>(_mm512_extractf32x4_ps::<3>(x)));
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn element_shift_in(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_in(self, x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec {
             /*
             let x: [f32; 16] = mem::transmute(x);
             let x: [f32; 16] = [*shift_in, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14]];
             mem::transmute(x)
             */
-            let shift_in = _mm512_castps128_ps512(_mm_load_ss(shift_in));
-            let index = mem::transmute([16u32, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
-            _mm512_mask_permutex2var_ps(x, !0, index, shift_in)
+            unsafe {
+                let shift_in = _mm512_castps128_ps512(_mm_load_ss(shift_in));
+                let index =
+                    mem::transmute([16u32, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+                _mm512_mask_permutex2var_ps(x, !0, index, shift_in)
+            }
         }
 
-        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+        #[inline]
+        fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
-            _mm512_slli_epi32::<1>(x)
+        #[inline]
+        fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec {
+            unsafe { _mm512_slli_epi32::<1>(x) }
         }
     }
 
-    #[cfg(feature = "nightly")]
-    pub struct AvxF64x8;
+    #[derive(Clone, Copy)]
+    pub struct AvxF64x8(());
 
-    #[cfg(feature = "nightly")]
+    impl AvxF64x8 {
+        #[inline]
+        pub fn new() -> Option<Self> {
+            if is_x86_feature_detected!("avx512f") {
+                Some(AvxF64x8(()))
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        pub fn new_unchecked() -> Self {
+            AvxF64x8(())
+        }
+    }
+
     impl Vector for AvxF64x8 {
         type Float = f64;
         type FloatArray = [f64; 8];
@@ -643,110 +759,118 @@ mod x86_64_avx512 {
 
         type Mode = u32;
 
-        unsafe fn set_flush_zero_mode() -> Self::Mode {
-            let mode = _MM_GET_FLUSH_ZERO_MODE();
-            _MM_SET_FLUSH_ZERO_MODE(0x8000);
-            mode
+        #[inline]
+        fn set_flush_zero_mode(self) -> Self::Mode {
+            unsafe {
+                let mode = _MM_GET_FLUSH_ZERO_MODE();
+                _MM_SET_FLUSH_ZERO_MODE(0x8000);
+                mode
+            }
         }
 
-        unsafe fn restore_flush_zero_mode(mode: Self::Mode) {
-            _MM_SET_FLUSH_ZERO_MODE(mode);
+        #[inline]
+        fn restore_flush_zero_mode(self, mode: Self::Mode) {
+            unsafe {
+                _MM_SET_FLUSH_ZERO_MODE(mode);
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn zero() -> Self::FloatVec {
-            _mm512_setzero_pd()
+        #[inline]
+        fn zero(self) -> Self::FloatVec {
+            unsafe { _mm512_setzero_pd() }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn first_element(f: Self::Float) -> Self::FloatVec {
-            _mm512_set_pd(0., 0., 0., 0., 0., 0., 0., f)
+        #[inline]
+        fn first_element(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm512_set_pd(0., 0., 0., 0., 0., 0., 0., f) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn splat(f: Self::Float) -> Self::FloatVec {
-            _mm512_set1_pd(f)
+        #[inline]
+        fn splat(self, f: Self::Float) -> Self::FloatVec {
+            unsafe { _mm512_set1_pd(f) }
         }
 
-        fn from_array(a: Self::FloatArray) -> Self::FloatVec {
+        #[inline]
+        fn from_array(self, a: Self::FloatArray) -> Self::FloatVec {
             unsafe { mem::transmute(a) }
         }
 
-        fn to_array(a: Self::FloatVec) -> Self::FloatArray {
+        #[inline]
+        fn to_array(self, a: Self::FloatVec) -> Self::FloatArray {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn add(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_add_pd(a, b)
+        #[inline]
+        fn add(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_add_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn sub(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_sub_pd(a, b)
+        #[inline]
+        fn sub(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_sub_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn mul(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_mul_pd(a, b)
+        #[inline]
+        fn mul(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_mul_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn div(a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
-            _mm512_div_pd(a, b)
+        #[inline]
+        fn div(self, a: Self::FloatVec, b: Self::FloatVec) -> Self::FloatVec {
+            unsafe { _mm512_div_pd(a, b) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn blend(
+        #[inline]
+        fn blend(
+            self,
             a: Self::FloatVec,
             b: Self::FloatVec,
             mask: Self::MaskVec,
         ) -> Self::FloatVec {
-            let bit = _mm512_set1_epi64(1 << 63);
-            let mask = _mm512_test_epi64_mask(mask, bit);
-            _mm512_mask_blend_pd(mask, a, b)
+            unsafe {
+                let bit = _mm512_set1_epi64(1 << 63);
+                let mask = _mm512_test_epi64_mask(mask, bit);
+                _mm512_mask_blend_pd(mask, a, b)
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn element_shift(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-            shift_out: &mut Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_out(self, x: Self::FloatVec, shift_out: &mut Self::Float) {
             /*
             let y: [f64; 8] = mem::transmute(x);
             *shift_out = y[7];
             */
             // TODO: missing _mm512_extractf64x2_pd?
-            _mm_storeh_pd(
-                shift_out,
-                mem::transmute(_mm512_extractf32x4_ps::<3>(mem::transmute(x))),
-            );
-            Self::element_shift_in(x, shift_in)
+            unsafe {
+                _mm_storeh_pd(
+                    shift_out,
+                    mem::transmute(_mm512_extractf32x4_ps::<3>(mem::transmute(x))),
+                );
+            }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn element_shift_in(
-            x: Self::FloatVec,
-            shift_in: *const Self::Float,
-        ) -> Self::FloatVec {
+        #[inline]
+        fn element_shift_in(self, x: Self::FloatVec, shift_in: &Self::Float) -> Self::FloatVec {
             /*
             let x: [f64; 8] = mem::transmute(x);
             let x: [f64; 8] = [*shift_in, x[0], x[1], x[2], x[3], x[4], x[5], x[6]];
             mem::transmute(x)
             */
-            let shift_in = _mm512_castpd128_pd512(_mm_load_sd(shift_in));
-            let index = mem::transmute([8u64, 0, 1, 2, 3, 4, 5, 6]);
-            _mm512_mask_permutex2var_pd(x, !0, index, shift_in)
+            unsafe {
+                let shift_in = _mm512_castpd128_pd512(_mm_load_sd(shift_in));
+                let index = mem::transmute([8u64, 0, 1, 2, 3, 4, 5, 6]);
+                _mm512_mask_permutex2var_pd(x, !0, index, shift_in)
+            }
         }
 
-        fn mask_from_array(a: Self::MaskArray) -> Self::MaskVec {
+        #[inline]
+        fn mask_from_array(self, a: Self::MaskArray) -> Self::MaskVec {
             unsafe { mem::transmute(a) }
         }
 
-        #[target_feature(enable = "avx512f")]
-        unsafe fn mask_shift(x: Self::MaskVec) -> Self::MaskVec {
-            _mm512_slli_epi64::<1>(x)
+        #[inline]
+        fn mask_shift(self, x: Self::MaskVec) -> Self::MaskVec {
+            unsafe { _mm512_slli_epi64::<1>(x) }
         }
     }
 }


### PR DESCRIPTION
Use structs like `AvxF32x8` as a token to signify that target
features have been checked.

Some performance improvements possibly due to inline changes.

Note: this causes a 16% performance regression in `forward_f64x4`
which will be tracked as a separate issue.

```
forward_f32x8           time:   [30.348 ms 30.359 ms 30.370 ms]
                        change: [-7.2267% -7.1551% -7.0925%] (p = 0.00 < 0.05)
                        Performance has improved.

forward_f32x16          time:   [15.857 ms 15.863 ms 15.870 ms]
                        change: [-2.6080% -2.5394% -2.4751%] (p = 0.00 < 0.05)
                        Performance has improved.

forward_f64x4           time:   [58.340 ms 58.404 ms 58.485 ms]
                        change: [+16.294% +16.865% +17.226%] (p = 0.00 < 0.05)
                        Performance has regressed.

forward_f64x8           time:   [25.140 ms 25.145 ms 25.149 ms]
                        change: [-4.0999% -3.8240% -3.5566%] (p = 0.00 < 0.05)
                        Performance has improved.
```