### PR TITLE
Fix `forward_f64x4` regression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! - AVX and AVX-512 versions of the PairHMM forward algorithm
 //! - AVX2 and AVX-512 versions of the Smith-Waterman sequence alignment algorithm
 #![deny(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(avx512_target_feature, stdsimd))]
+#![cfg_attr(feature = "nightly", feature(avx512_target_feature, stdsimd, asm))]
 
 mod vector;
 


### PR DESCRIPTION
Unfortunately the full fix requires nightly rust for inline asm,
but this is still a partial fix for stable rust.

```
forward_f64x4           time:   [49.255 ms 49.378 ms 49.514 ms]
                        change: [-18.062% -17.685% -17.303%] (p = 0.00 < 0.05)
                        Performance has improved.
```