### PR TITLE
smithwaterman: cleanups and comments

### DIFF
--- a/src/smithwaterman.rs
+++ b/src/smithwaterman.rs
@@ -269,13 +269,13 @@ fn compute<V: Int32Vector>(
     // The oldest is overwritten in place as we proceed along the antidiagonal.
     let hwidth = max_len + V::LANES;
     let mut h = vec![0i32; 2 * hwidth];
-    //h[max_len / 2] = 0;
 
     let mut max_score = i32::MIN;
     let mut max_i = 0;
     let mut max_j = 0;
 
-    // TODO: extra antidiagonal?
+    // Note: the first antidiagonal has jlo > jhi, but we use it to
+    // initialize H(0, 1) and H(1, 0).
     for antidiag in 1..=(nrow + ncol) {
         // Calculate endpoints of the antidiagonal: (ilo, jlo) -> (ihi, jhi).
         // Invariant: i + j == antidiag

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1278,12 +1278,8 @@ mod x86_64_avx512 {
         #[inline]
         fn pack(self, a: Self::Vec, b: Self::Vec) -> Self::Pack {
             unsafe {
-                let idx_even =
-                    _mm512_set_epi32(27, 26, 25, 24, 19, 18, 17, 16, 11, 10, 9, 8, 3, 2, 1, 0);
-                let idx_odd =
-                    _mm512_set_epi32(31, 30, 29, 28, 23, 22, 21, 20, 15, 14, 13, 12, 7, 6, 5, 4);
-                let even = _mm512_permutex2var_epi32(a, idx_even, b);
-                let odd = _mm512_permutex2var_epi32(a, idx_odd, b);
+                let even = _mm512_shuffle_i64x2::<0b10_00_10_00>(a, b);
+                let odd = _mm512_shuffle_i64x2::<0b11_01_11_01>(a, b);
                 _mm512_packs_epi32(even, odd)
             }
         }


### PR DESCRIPTION
As part of adding these comments, I have discovered that the algorithm is actually Needleman-Wunsch (global alignment) modified with overhang handling, not Smith-Waterman (local alignment). See https://github.com/broadinstitute/gatk/issues/6576.